### PR TITLE
chore: add `google/flatbuffers` as a git submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "flatbuffers"]
+	path = flatbuffers
+	url = https://github.com/google/flatbuffers


### PR DESCRIPTION
This is in preparation for building `flatc` on release with github actions.