### PR TITLE
ci: add `release.yml` for generating changelogs

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,17 @@
+changelog:
+  categories:
+    - title: 🐛 Bug fixes
+      labels:
+        - 'type: bug'
+    - title: 📦 Chore
+      labels:
+        - 'type: chore'
+    - title: 🔁 Continuous Integration
+      labels:
+        - 'type: CI'
+    - title: 📝 Documentation
+      labels:
+        - 'type: docs'
+    - title: 🏕 Features
+      labels:
+        - 'type: feature'


### PR DESCRIPTION
This yaml config is used by GitHub for automatically generating changelog for a release. See: [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).